### PR TITLE
Use the SciJava fork of Java 3D vecmath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>7.1.1</version>
+		<version>18.1.0</version>
 		<relativePath />
 	</parent>
 
 	<artifactId>imagescience</artifactId>
-	<version>3.0.0</version>
+	<version>4.0.0-SNAPSHOT</version>
 
 	<name>jars/imagescience.jar</name>
 	<description />
@@ -68,9 +68,10 @@
 			<groupId>sc.fiji</groupId>
 			<artifactId>Image_5D</artifactId>
 		</dependency>
-		<!-- Third party dependencies -->
+
+		<!-- Java 3D dependencies -->
 		<dependency>
-			<groupId>java3d</groupId>
+			<groupId>org.scijava</groupId>
 			<artifactId>vecmath</artifactId>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
 		<tag>HEAD</tag>
 		<url>https://github.com/fiji/imagescience</url>
 	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/fiji/imagescience/issues</url>
+	</issueManagement>
 	<ciManagement>
 		<system>Jenkins</system>
 		<url>http://jenkins.imagej.net/job/imagescience/</url>

--- a/src/main/java/imagescience/mesh/Cone.java
+++ b/src/main/java/imagescience/mesh/Cone.java
@@ -2,7 +2,7 @@ package imagescience.mesh;
 
 import java.util.Vector;
 
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 
 /** Triangular mesh of a cone in 3D. */
 public class Cone {

--- a/src/main/java/imagescience/mesh/Cube.java
+++ b/src/main/java/imagescience/mesh/Cube.java
@@ -2,7 +2,7 @@ package imagescience.mesh;
 
 import java.util.Vector;
 
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 
 /** Triangular mesh of a cube in 3D. */
 public class Cube {

--- a/src/main/java/imagescience/mesh/Cylinder.java
+++ b/src/main/java/imagescience/mesh/Cylinder.java
@@ -2,7 +2,7 @@ package imagescience.mesh;
 
 import java.util.Vector;
 
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 
 /** Triangular mesh of a cylinder in 3D. */
 public class Cylinder {

--- a/src/main/java/imagescience/mesh/Sphere.java
+++ b/src/main/java/imagescience/mesh/Sphere.java
@@ -3,7 +3,7 @@ package imagescience.mesh;
 import java.util.Hashtable;
 import java.util.Vector;
 
-import javax.vecmath.Point3f;
+import org.scijava.vecmath.Point3f;
 
 /** Triangular mesh of a sphere in 3D. The mesh is created by recursive subdivision of an icosahedron. */
 public class Sphere {


### PR DESCRIPTION
This avoids deployment issues related to Java 3D.

Ultimately, we will switch again to the official Java 3D 1.7 vecmath (maintained by JogAmp; package prefix `org.jogamp.vecmath`). But it is not released yet, so for now we use the [SciJava version](https://github.com/scijava/vecmath).

Note that this bumps the version to `4.0.0-SNAPSHOT`, since by SemVer this is a backwards incompatible change [requiring a major version bump](http://imagej.net/Fiji_contribution_requirements#Versioning_and_dependency_convergence). (E.g.: `Cube#render(Point3f, float)` uses `Point3f` with the new package prefix.)

For details and rationale, see:
- [This (now outdated) forum post](http://forum.imagej.net/t/java-3d-progress-and-next-steps/135)
- [This JogAmp forum thread](http://forum.jogamp.org/Java-3D-Use-Maven-to-build-and-publish-Maven-artifacts-td4035555.html)
